### PR TITLE
fix: restore file content extraction — release v4.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.2.1] - 2026-06-30
+
+### Fixed
+- **Critical regression**: file contents were no longer extracted — the output
+  contained only the directory tree and every file was wrongly reported as
+  "empty" (`Processed 0 files`). The content extraction pipeline now reads and
+  writes file contents correctly again.
+- `should_process_file()`: extension matching now strips a leading dot
+  (e.g. `--include .py` and `--include py` behave identically) and files without
+  an extension are handled correctly in both include and exclude modes.
+- `list_files_to_process()`: rebuilt around a single `find` invocation with
+  proper directory, filename and extension filtering, emitting NUL-delimited
+  paths so filenames with spaces are handled safely.
+- Removed a stray control character from the content-reading `sed` pipeline that
+  could corrupt or blank out file contents.
+- Replaced `mapfile` with a Bash 3.2-compatible read loop so the script runs on
+  macOS's default Bash.
+
 ## [4.2] - 2025-12-18
 
 ### Added

--- a/codepack.sh
+++ b/codepack.sh
@@ -4,7 +4,7 @@
 # Author: Ɛɔıs3 Solutions
 # GitHub: https://github.com/w3spi5
 # License: MIT
-# Version: 4.2
+# Version: 4.2.1
 # Dependencies: Optional external minifiers for maximum compression
 # ----------------------------------------------------------------------------
 
@@ -935,7 +935,7 @@ main() {
     check_minifiers
 
     echo ""
-    echo "🔧 codepack v4.2"
+    echo "🔧 codepack v4.2.1"
     echo "Automatically excluding directories: $(printf "'%s', " "${exclude_dirs[@]}" | sed 's/, $//')"
     echo "Automatically excluding files: $(printf "'%s', " "${exclude_files[@]}" | sed 's/, $//')"
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@w3spi5/codepack",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "keywords": [
     "cli",
     "minify",


### PR DESCRIPTION
## Context

The published **v4.2** release is flagged on GitHub as *"DON'T USE, IT WON'T WORK !!"*. Reproducing it confirms the regression: codepack generated an output file containing **only the directory tree**, and every file was wrongly reported as empty:

```
📝 Processed 0 files (skipped 5 empty files)
```

No file contents were ever written to the output — making the tool useless for its core purpose (feeding code to an AI).

## Root cause

The content-extraction pipeline in the v4.2 tag was broken (corrupted `sed` step in the file reader, fragile file-listing, and `mapfile` usage incompatible with macOS's default Bash). The working extraction logic was already restored on `main` through the follow-up fixes (PRs #14–#19), but **no new release was ever cut**, so users installing `@w3spi5/codepack` still get the broken v4.2.

## What this PR does

This is the release cut: it bumps the version so a fixed package can be published. No behavioural code changes beyond the version string — the extraction fixes are already on `main`.

- Bump version `4.2` → `4.2.1` in the script header, the `main()` banner, and `package.json`
- Document the regression fixes in `CHANGELOG.md` (new `[4.2.1]` section)

## Verification

- `test/test_basic.sh` ✅ and `test/test_features.sh` ✅ pass
- `bash -n codepack.sh` syntax check ✅
- Manual runs confirm file **contents are extracted** again across normal, `--include`, `--exclude` and `--minify` modes (e.g. 17/18 files processed with real content vs. 0/5 on the broken v4.2)

After merge to `main`, the `Test & Publish` workflow publishes the fixed package to GitHub Packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y2XJw3TXS1EuWdgmnGD4ts)_