### PR TITLE
ci: fix GitHub Packages publish 401 so v4.2.1 actually publishes

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,11 +43,15 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           registry-url: 'https://npm.pkg.github.com'
           scope: '@w3spi5'
 
       - name: Publish to GitHub Packages
         run: npm publish
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          # Use the automatically-provided GITHUB_TOKEN (with packages: write
+          # permission granted above) instead of a separate NPM_TOKEN secret.
+          # The previous NPM_TOKEN was unauthenticated (npm error 401), which
+          # blocked every release publish after v4.2.
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git://github.com/w3spi5/codepack.git"
+    "url": "git+https://github.com/w3spi5/codepack.git"
   },
   "author": "w3spi5",
   "license": "MIT",


### PR DESCRIPTION
## Context

Follow-up to #27. After #27 merged, the `Test & Publish` workflow ran on `main` and the **`publish` job failed** — as it had on every push to `main` since v4.2. The tests pass; only publishing fails:

```
npm notice 📦  @w3spi5/codepack@4.2.1
npm error code E401
npm error 401 Unauthorized - PUT https://npm.pkg.github.com/@w3spi5%2fcodepack
      unauthenticated: User cannot be authenticated with the token provided.
```

The 4.2.1 tarball builds correctly — the package was **never published** purely because the `NPM_TOKEN` secret used for authentication is missing/expired/lacking `write:packages` scope. This is the real reason no working release exists on GitHub Packages after v4.2, independent of the content-extraction regression fixed in #27.

## What this PR does

- **Authenticate with `GITHUB_TOKEN`** instead of `NPM_TOKEN`. The `publish` job already declares `permissions: packages: write`, so the auto-provisioned `GITHUB_TOKEN` can publish this repo's scoped package to GitHub Packages — no manually-managed secret required.
- **Normalize the `repository` URL** in `package.json` from the deprecated `git://` to `git+https://` so GitHub Packages reliably links the package to this repository for token-based auth.
- **Bump the workflow Node.js version `20` → `22`** (Node 20 is deprecated on GitHub Actions runners).

No change to the package contents or to `codepack.sh` behaviour — `4.2.1` (already on `main`) stays the version being published, and it has not been published yet, so there is no version conflict.

## Verification

- `package.json` parses as valid JSON; `publish.yml` parses as valid YAML
- Once merged to `main`, the `publish` job should authenticate via `GITHUB_TOKEN` and publish `@w3spi5/codepack@4.2.1` to GitHub Packages
- `test` job is unaffected and continues to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y2XJw3TXS1EuWdgmnGD4ts)_