### PR TITLE
ci: drop hardcoded NPM_TOKEN from .npmrc so v4.2.1 finally publishes

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,1 @@
-//npm.pkg.github.com/:_authToken=${NPM_TOKEN}
 @w3spi5:registry=https://npm.pkg.github.com


### PR DESCRIPTION
## Context

Follow-up to #28. Even after switching the workflow to `GITHUB_TOKEN`, the `publish` job on `main` **still failed with 401**:

```
npm notice 📦  @w3spi5/codepack@4.2.1
npm error code E401
npm error 401 Unauthorized - PUT https://npm.pkg.github.com/@w3spi5%2fcodepack
      unauthenticated: User cannot be authenticated with the token provided.
```

## Root cause

The repository-level `.npmrc` pinned the auth token to a variable that is no longer set:

```
//npm.pkg.github.com/:_authToken=${NPM_TOKEN}
@w3spi5:registry=https://npm.pkg.github.com
```

A **project `.npmrc` takes precedence** over the config that `actions/setup-node` writes (`NPM_CONFIG_USERCONFIG`). So this line overrode the CI-provided `NODE_AUTH_TOKEN`; with `NPM_TOKEN` unset, `${NPM_TOKEN}` expanded to an **empty string**, and npm authenticated with no token → 401. The `GITHUB_TOKEN` set in #28 was never actually consulted.

## What this PR does

- Remove the hardcoded `_authToken` line from `.npmrc`, keeping only the scope → registry mapping.
- `actions/setup-node` now supplies authentication via `NODE_AUTH_TOKEN` (`GITHUB_TOKEN`) in its own generated config, which is exactly what the deprecated line was blocking.

No package-content or `codepack.sh` change — `4.2.1` (already on `main`, still unpublished) remains the version to be published, so there is no version conflict.

## Verification

- `.npmrc` still maps the `@w3spi5` scope to GitHub Packages for local use
- Once merged, the `publish` job's `npm publish` should authenticate via `GITHUB_TOKEN` and publish `@w3spi5/codepack@4.2.1` to GitHub Packages
- `test` job is unaffected

Note: if publishing still fails after this (e.g. GitHub Packages "Actions access" for the existing package doesn't include this repo), that would be a package-settings change only the maintainer can make in the repo/package UI — I'll report clearly if that turns out to be the case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y2XJw3TXS1EuWdgmnGD4ts)_