### PR TITLE
release: bump version to 5.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.0.0] - 2026-07-01
+
+### Changed
+- Version bumped to 5.0.0 to mark the first fully working, publishable release
+  after the broken v4.2 line. No breaking changes to the CLI: all flags and
+  output formats are unchanged — existing commands keep working as-is.
+
+### Note
+- This release consolidates the content-extraction and GitHub Packages
+  publishing fixes introduced in 4.2.1 (see below) under a clean 5.x baseline.
+
 ## [4.2.1] - 2026-06-30
 
 ### Fixed

--- a/codepack.sh
+++ b/codepack.sh
@@ -4,7 +4,7 @@
 # Author: Ɛɔıs3 Solutions
 # GitHub: https://github.com/w3spi5
 # License: MIT
-# Version: 4.2.1
+# Version: 5.0.0
 # Dependencies: Optional external minifiers for maximum compression
 # ----------------------------------------------------------------------------
 
@@ -930,7 +930,7 @@ main() {
     check_minifiers
 
     echo ""
-    echo "🔧 codepack v4.2.1"
+    echo "🔧 codepack v5.0.0"
     echo "Automatically excluding directories: $(printf "'%s', " "${exclude_dirs[@]}" | sed 's/, $//')"
     echo "Automatically excluding files: $(printf "'%s', " "${exclude_files[@]}" | sed 's/, $//')"
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@w3spi5/codepack",
-  "version": "4.2.1",
+  "version": "5.0.0",
   "keywords": [
     "cli",
     "minify",


### PR DESCRIPTION
## What

Bump the version from `4.2.1` to **`5.0.0`**, promoting the first fully working, publishable build to a clean 5.x baseline.

- `codepack.sh` header `# Version:` → `5.0.0`
- `codepack.sh` `main()` banner → `codepack v5.0.0`
- `package.json` `version` → `5.0.0`
- New `[5.0.0]` section in `CHANGELOG.md`

## Notes

- **No CLI behaviour changes** — all flags (`--include`, `--exclude`, `--minify`, `--compress`, `--copy`, …) and the output format are unchanged. The major bump reflects the fresh, working baseline, not a breaking change.
- `5.0.0` has not been published yet, so there is no version conflict when the `publish` job runs on `main`.

## Verification

- `bash -n codepack.sh` ✅
- `test/test_basic.sh` ✅ and `test/test_features.sh` ✅ pass
- `package.json` is valid and reports `5.0.0`

After merge to `main`, the `Test & Publish` workflow publishes `@w3spi5/codepack@5.0.0` to GitHub Packages (auth is already fixed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y2XJw3TXS1EuWdgmnGD4ts)_